### PR TITLE
Stub get latest github repo ref

### DIFF
--- a/src/api/github/controllers/commits.js
+++ b/src/api/github/controllers/commits.js
@@ -27,4 +27,20 @@ const patchRefsController = {
   }
 }
 
-export { repoCommitsController, postCommitsController, patchRefsController }
+const getRefsController = {
+  handler: async (request, h) => {
+    const ref = {
+      object: {
+        sha: 'aa218f56b14c9653891f9e74264a383fa43fefbd'
+      }
+    }
+    return h.response(ref).code(200)
+  }
+}
+
+export {
+  getRefsController,
+  repoCommitsController,
+  postCommitsController,
+  patchRefsController
+}

--- a/src/api/github/controllers/commits.test.js
+++ b/src/api/github/controllers/commits.test.js
@@ -1,0 +1,20 @@
+import { getRefsController } from '~/src/api/github/controllers/commits'
+
+describe('Github Commits API', () => {
+  let mockViewHandler
+  describe('getRefsController', () => {
+    mockViewHandler = {
+      response: jest.fn().mockReturnThis(),
+      code: jest.fn().mockReturnThis()
+    }
+    it('should return the latest ref', async () => {
+      await getRefsController.handler(null, mockViewHandler)
+      expect(mockViewHandler.response).toHaveBeenCalledWith({
+        object: {
+          sha: 'aa218f56b14c9653891f9e74264a383fa43fefbd'
+        }
+      })
+      expect(mockViewHandler.code).toHaveBeenCalledWith(200)
+    })
+  })
+})

--- a/src/api/github/index.js
+++ b/src/api/github/index.js
@@ -3,6 +3,7 @@ import { updateRepo } from '~/src/api/github/controllers/update-repo'
 import { getRepoController } from '~/src/api/github/controllers/get-repo'
 import { gitTreeController } from '~/src/api/github/controllers/gitTree'
 import {
+  getRefsController,
   patchRefsController,
   postCommitsController,
   repoCommitsController
@@ -51,6 +52,11 @@ const githubStub = {
           method: 'POST',
           path: '/graphql',
           ...graphqlController
+        },
+        {
+          method: 'GET',
+          path: '/repos/{org}/{repo}/git/refs/{path}',
+          ...getRefsController
         },
         {
           method: 'PATCH',


### PR DESCRIPTION
Stubs out fetching the latest ref from a repo. 
IE a GET to `https://api.github.com/repos/OWNER/REPO/git/ref/REF`