### PR TITLE
Secrets lambda listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,19 +198,46 @@ being returned in the mock API calls.
 
 Add to pending in portal backend.
 
-`curl -H "Content-Type: application/json" -d '{"environment":"infra-dev", "service": "cdp-portal-frontend","secretKey":"SOME_KEY","action":"add_secret"}'  http://localhost:5094/secrets/register/pending`
+```bash
+curl -H "Content-Type: application/json" -d \
+   '{"environment":"infra-dev", "service": "cdp-portal-frontend","secretKey":"SOME_KEY","action":"add_secret"}' \
+   http://localhost:5094/secrets/register/pending
+```
 
 Add to queue that simulates the lambda consuming it after a slight delay.
 
-`awslocal sqs send-message --queue-url "http://localhost:4566/000000000000/secret_management_updates_lambda" --region eu-west-2 --message-body '{"source": "cdp-secret-manager-lambda", "statusCode": 200, "action": "add_secret", "Message": {"action": "add_secret", "name": "cdp-portal-frontend",  "environment": "infra-dev", "secret_key": "SOME_KEY", "secret_value": "Some value"}}'`
+```bash
+awslocal sqs send-message --queue-url \
+  "http://localhost:4566/000000000000/secret_management_updates_lambda" \
+  --region eu-west-2 --message-body \
+  '{"source": "cdp-secret-manager-lambda", "statusCode": 200, "action": "add_secret", "Message": {"action": "add_secret", "name": "cdp-portal-frontend",  "environment": "infra-dev", "secret_key": "SOME_KEY", "secret_value": "Some value"}}'
+```
 
 Or add directly to Portal Backend.
 
-`awslocal sqs send-message --queue-url "http://localhost:4566/000000000000/secret_management_updates" --region eu-west-2 --message-body '{"source": "cdp-secret-manager-lambda", "statusCode": 200, "action": "add_secret", "body": {"add_secret": true, "secret": "cdp/services/cdp-portal-frontend",  "environment": "infra-dev", "secret_key": "SOME_KEY" }}'`
+```bash
+awslocal sqs send-message --queue-url \
+  "http://localhost:4566/000000000000/secret_management_updates" \
+  --region eu-west-2 --message-body \
+  '{"source": "cdp-secret-manager-lambda", "statusCode": 200, "action": "add_secret", "body": {"add_secret": true, "secret": "cdp/services/cdp-portal-frontend",  "environment": "infra-dev", "secret_key": "SOME_KEY" }}'
+```
+
+Or publish to topic that fans out to the queue.
+
+```bash
+awslocal sns publish \
+  --topic-arn "arn:aws:sns:eu-west-2:000000000000:secret_management" \
+  --message '{"action": "add_secret", "name": "cdp-portal-frontend",  "environment": "infra-dev", "secret_key": "SOME_KEY", "secret_value": "Some value"}'
+```
 
 Add `BLOWUP` as value to simulate the lambda throwing exception.
 
-`awslocal sqs send-message --queue-url "http://localhost:4566/000000000000/secret_management_updates_lambda" --region eu-west-2 --message-body '{"source": "cdp-secret-manager-lambda", "statusCode": 200, "action": "add_secret", "Message": {"action": "add_secret", "name": "cdp-portal-frontend",  "environment": "infra-dev", "secret_key": "SOME_KEY", "secret_value": "BLOWUP"}}'`
+```bash
+awslocal sqs send-message --queue-url \
+  "http://localhost:4566/000000000000/secret_management_updates_lambda" \
+  --region eu-west-2 --message-body \
+  '{"source": "cdp-secret-manager-lambda", "statusCode": 200, "action": "add_secret", "Message": {"action": "add_secret", "name": "cdp-portal-frontend",     "environment": "infra-dev", "secret_key": "SOME_KEY", "secret_value": "BLOWUP"}}'
+```
 
 #### Get all secret
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,12 @@ awslocal sqs create-queue --queue-name github-events --region eu-west-2
 awslocal sqs create-queue --queue-name deployments-from-portal --region eu-west-2
 awslocal sqs create-queue --queue-name run-test-from-portal
 awslocal sns create-topic --name run-test-topic
-awslocal sns subscribe --topic-arn arn:aws:sns:$AWS_REGION:000000000000:run-test-topic --protocol sqs --notification-endpoint  arn:aws:sqs:eu-west-2:000000000000:run-test-from-portal
+awslocal sns subscribe --topic-arn arn:aws:sns:eu-west-2:000000000000:run-test-topic --protocol sqs --notification-endpoint  arn:aws:sqs:eu-west-2:000000000000:run-test-from-portal
+awslocal sns create-topic --name secret_management
+awslocal sqs create-queue --queue-name secret_management_updates
+awslocal sqs create-queue --queue-name secret_management_updates_lambda
+awslocal sns subscribe --topic-arn arn:aws:sns:eu-west-2:000000000000:secret_management --protocol sqs --notification-endpoint  arn:aws:sqs:eu-west-2:000000000000:secret_management_updates
+awslocal sns subscribe --topic-arn arn:aws:sns:eu-west-2:000000000000:secret_management --protocol sqs --notification-endpoint  arn:aws:sqs:eu-west-2:000000000000:secret_management_updates_lambda
 ```
 
 ### Setup cdp-portal-stubs
@@ -186,3 +191,29 @@ AZURE_CLIENT_SECRET=test_value GITHUB_BASE_URL=http://localhost:3939  OIDC_WELL_
 
 The base set of services is held in /config/mock-data.js. Adding or removing services to this list will result in them
 being returned in the mock API calls.
+
+### Stub Secrets
+
+#### Add secret
+
+Add to pending in portal backend.
+
+`curl -H "Content-Type: application/json" -d '{"environment":"infra-dev", "service": "cdp-portal-frontend","secretKey":"SOME_KEY","action":"add_secret"}'  http://localhost:5094/secrets/register/pending`
+
+Add to queue that simulates the lambda consuming it after a slight delay.
+
+`awslocal sqs send-message --queue-url "http://localhost:4566/000000000000/secret_management_updates_lambda" --region eu-west-2 --message-body '{"source": "cdp-secret-manager-lambda", "statusCode": 200, "action": "add_secret", "Message": {"action": "add_secret", "name": "cdp-portal-frontend",  "environment": "infra-dev", "secret_key": "SOME_KEY", "secret_value": "Some value"}}'`
+
+Or add directly to Portal Backend.
+
+`awslocal sqs send-message --queue-url "http://localhost:4566/000000000000/secret_management_updates" --region eu-west-2 --message-body '{"source": "cdp-secret-manager-lambda", "statusCode": 200, "action": "add_secret", "body": {"add_secret": true, "secret": "cdp/services/cdp-portal-frontend",  "environment": "infra-dev", "secret_key": "SOME_KEY" }}'`
+
+Add `BLOWUP` as value to simulate the lambda throwing exception.
+
+`awslocal sqs send-message --queue-url "http://localhost:4566/000000000000/secret_management_updates_lambda" --region eu-west-2 --message-body '{"source": "cdp-secret-manager-lambda", "statusCode": 200, "action": "add_secret", "Message": {"action": "add_secret", "name": "cdp-portal-frontend",  "environment": "infra-dev", "secret_key": "SOME_KEY", "secret_value": "BLOWUP"}}'`
+
+#### Get all secret
+
+Updates secret keys in portal backend.
+
+`awslocal sqs send-message --queue-url "http://localhost:4566/000000000000/secret_management_updates" --region eu-west-2 --message-body '{"source": "cdp-secret-manager-lambda", "statusCode": 200, "action": "get_all_secret_keys", "body": {"environment": "infra-dev", "secretKeys": {"/cdp/services/cdp-portal-frontend": {"keys": ["TEST_KEY"],"lastChangedDate":"2024-07-01 10:05:15","createdDate":"2024-07-01 10:05:15"}}}}'`

--- a/localstack-setup.sh
+++ b/localstack-setup.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 export AWS_REGION=eu-west-2
 export LOCALSTACK_URL=http://127.0.0.1:4566
+
+aws --endpoint $LOCALSTACK_URL sqs create-queue --queue-name ecr-push-deployments
 aws --endpoint $LOCALSTACK_URL sqs create-queue --queue-name ecs-deployments
 aws --endpoint $LOCALSTACK_URL sqs create-queue --queue-name ecr-push-events
 aws --endpoint $LOCALSTACK_URL sqs create-queue --queue-name github-events
+aws --endpoint $LOCALSTACK_URL sqs create-queue --queue-name deployments-from-portal
+aws --endpoint $LOCALSTACK_URL sqs create-queue --queue-name run-test-from-portal
+aws --endpoint $LOCALSTACK_URL sqs create-queue --queue-name secret_management_updates
+aws --endpoint $LOCALSTACK_URL sqs create-queue --queue-name secret_management_updates_lambda
+aws --endpoint $LOCALSTACK_URL sns create-topic --name run-test-topic
+aws --endpoint $LOCALSTACK_URL sns create-topic --name secret_management
+aws --endpoint $LOCALSTACK_URL sns subscribe --topic-arn arn:aws:sns:$AWS_REGION:000000000000:run-test-topic --protocol sqs --notification-endpoint  arn:aws:sqs:$AWS_REGION:000000000000:run-test-from-portal
+aws --endpoint $LOCALSTACK_URL sns subscribe --topic-arn arn:aws:sns:$AWS_REGION:000000000000:secret_management --protocol sqs --notification-endpoint  arn:aws:sqs:$AWS_REGION:000000000000:secret_management_updates
+aws --endpoint $LOCALSTACK_URL sns subscribe --topic-arn arn:aws:sns:$AWS_REGION:000000000000:secret_management --protocol sqs --notification-endpoint  arn:aws:sqs:$AWS_REGION:000000000000:secret_management_updates_lambda

--- a/src/api/lambda/secrets-updates-handler.js
+++ b/src/api/lambda/secrets-updates-handler.js
@@ -1,0 +1,44 @@
+import { createLogger } from '~/src/helpers/logging/logger'
+import { SendMessageCommand } from '@aws-sdk/client-sqs'
+
+import { config } from '~/src/config'
+
+const logger = createLogger()
+const secretsUpdatedDelay = config.get('lambda.secretsUpdates.delay')
+const secretsUpdatedQueue = config.get('lambda.secretsUpdates.queue')
+
+async function secretUpdatesHandler(sqs, payload) {
+  logger.info(payload.Message, 'Secrets update received')
+  const msg = JSON.parse(payload.Message)
+  const name = msg?.name
+  const environment = msg?.environment
+  const action = msg?.action
+  //   const description = msg?.description
+  const secretKey = msg?.secret_key
+  //   const secretValue = msg?.secret_value
+
+  if (action === 'add_secret') {
+    logger.info(`Adding secret ${secretKey} for ${name} in ${environment}`)
+    addSecret(sqs, name, secretKey)
+  }
+}
+
+async function addSecret(sqs, name, secretKey) {
+  const payload = {
+    add_secret: true,
+    secret: name,
+    secretKey,
+    exception: ''
+  }
+  const updatedMessage = {
+    QueueUrl: secretsUpdatedQueue,
+    MessageBody: JSON.stringify(payload),
+    DelaySeconds: secretsUpdatedDelay,
+    MessageAttributes: {},
+    MessageSystemAttributes: {}
+  }
+  const command = new SendMessageCommand(updatedMessage)
+  return await sqs.send(command)
+}
+
+export { secretUpdatesHandler }

--- a/src/api/lambda/secrets-updates-listener.js
+++ b/src/api/lambda/secrets-updates-listener.js
@@ -1,0 +1,43 @@
+import { Consumer } from 'sqs-consumer'
+import { secretUpdatesHandler } from '~/src/api/lambda/secret-updates-handler'
+
+const { config } = require('~/src/config')
+
+function secretUpdatesListener(server) {
+  const queueUrl = config.get('lambda.secretsUpdates.queue')
+
+  server.logger.info(`Listening for secrets updates events on ${queueUrl}`)
+
+  const sqs = server.sqs
+  const listener = Consumer.create({
+    queueUrl,
+    attributeNames: ['SentTimestamp'],
+    messageAttributeNames: ['All'],
+    waitTimeSeconds: 10,
+    visibilityTimeout: 400,
+    handleMessage: async (message) => {
+      const payload = JSON.parse(message.Body)
+      await secretUpdatesHandler(server.sqs, payload)
+      return message
+    },
+    sqs
+  })
+
+  listener.on('error', (error) => {
+    server.logger.error(error.message)
+  })
+
+  listener.on('processing_error', (error) => {
+    server.logger.error(error.message)
+  })
+
+  listener.on('timeout_error', (error) => {
+    server.logger.error(error.message)
+  })
+
+  listener.start()
+
+  return listener
+}
+
+export { secretUpdatesListener }

--- a/src/api/lambda/secrets-updates-listener.js
+++ b/src/api/lambda/secrets-updates-listener.js
@@ -1,10 +1,10 @@
 import { Consumer } from 'sqs-consumer'
-import { secretUpdatesHandler } from '~/src/api/lambda/secret-updates-handler'
+import { secretsUpdatesHandler } from '~/src/api/lambda/secrets-updates-handler'
 
 const { config } = require('~/src/config')
 
-function secretUpdatesListener(server) {
-  const queueUrl = config.get('lambda.secretsUpdates.queue')
+function secretsUpdatesListener(server) {
+  const queueUrl = config.get('lambda.secretsUpdates.queueIn')
 
   server.logger.info(`Listening for secrets updates events on ${queueUrl}`)
 
@@ -14,10 +14,10 @@ function secretUpdatesListener(server) {
     attributeNames: ['SentTimestamp'],
     messageAttributeNames: ['All'],
     waitTimeSeconds: 10,
-    visibilityTimeout: 400,
+    visibilityTimeout: 20,
     handleMessage: async (message) => {
       const payload = JSON.parse(message.Body)
-      await secretUpdatesHandler(server.sqs, payload)
+      await secretsUpdatesHandler(server.sqs, payload)
       return message
     },
     sqs
@@ -40,4 +40,4 @@ function secretUpdatesListener(server) {
   return listener
 }
 
-export { secretUpdatesListener }
+export { secretsUpdatesListener }

--- a/src/api/lambda/secrets-updates-plugin.js
+++ b/src/api/lambda/secrets-updates-plugin.js
@@ -1,0 +1,13 @@
+import { secretUpdatesListener } from '~/src/api/lambda/secrets-updates-listener'
+
+const secretUpdatesPlugin = {
+  plugin: {
+    name: 'secretUpdatesPlugin',
+    version: '1.0.0',
+    register: function (server) {
+      secretUpdatesListener(server)
+    }
+  }
+}
+
+export { secretUpdatesPlugin }

--- a/src/api/lambda/secrets-updates-plugin.js
+++ b/src/api/lambda/secrets-updates-plugin.js
@@ -1,13 +1,13 @@
-import { secretUpdatesListener } from '~/src/api/lambda/secrets-updates-listener'
+import { secretsUpdatesListener } from '~/src/api/lambda/secrets-updates-listener'
 
-const secretUpdatesPlugin = {
+const secretsUpdatesPlugin = {
   plugin: {
     name: 'secretUpdatesPlugin',
     version: '1.0.0',
     register: function (server) {
-      secretUpdatesListener(server)
+      secretsUpdatesListener(server)
     }
   }
 }
 
-export { secretUpdatesPlugin }
+export { secretsUpdatesPlugin }

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -9,6 +9,7 @@ import { mongoPlugin } from '~/src/helpers/mongodb'
 import { failAction } from '~/src/helpers/fail-action'
 import { sqsPlugin } from '~/src/helpers/sqs'
 import { deploymentEventsPlugin } from '~/src/api/ecs/deployment-events-plugin'
+import { secretUpdatesPlugin } from '~/src/api/lambdas/secret-updates-plugin'
 
 async function createServer() {
   const server = hapi.server({
@@ -38,8 +39,8 @@ async function createServer() {
   await server.register(router, {})
 
   await server.register(sqsPlugin)
-
   await server.register(deploymentEventsPlugin)
+  await server.register(secretUpdatesPlugin)
 
   return server
 }

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -9,7 +9,7 @@ import { mongoPlugin } from '~/src/helpers/mongodb'
 import { failAction } from '~/src/helpers/fail-action'
 import { sqsPlugin } from '~/src/helpers/sqs'
 import { deploymentEventsPlugin } from '~/src/api/ecs/deployment-events-plugin'
-import { secretUpdatesPlugin } from '~/src/api/lambdas/secret-updates-plugin'
+import { secretsUpdatesPlugin } from '~/src/api/lambda/secrets-updates-plugin'
 
 async function createServer() {
   const server = hapi.server({
@@ -40,7 +40,7 @@ async function createServer() {
 
   await server.register(sqsPlugin)
   await server.register(deploymentEventsPlugin)
-  await server.register(secretUpdatesPlugin)
+  await server.register(secretsUpdatesPlugin)
 
   return server
 }

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -157,6 +157,23 @@ const config = convict({
     format: String,
     default: 'http://127.0.0.1:4566/000000000000/run-test-from-portal',
     env: 'SQS_TEST_RUNS_FROM_PORTAL'
+  },
+  lambda: {
+    secretsUpdates: {
+      queue: {
+        doc: 'A queue that normally receives messages from self service and responded by a lambda',
+        format: String,
+        default:
+          'http://a127.0.0.1:4566/000000000000/secret_management_updates',
+        env: 'SQS_SECRET_UPDATES'
+      },
+      delay: {
+        doc: 'A delay before processing secrets  elf service and responded by a lambda',
+        format: Number,
+        default: '2000',
+        env: 'SQS_SECRET_UPDATES_DELAY'
+      }
+    }
   }
 })
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -160,17 +160,23 @@ const config = convict({
   },
   lambda: {
     secretsUpdates: {
-      queue: {
-        doc: 'A queue that normally receives messages from self service and responded by a lambda',
+      queueIn: {
+        doc: 'A queue that normally receives messages from self service ops',
         format: String,
         default:
-          'http://a127.0.0.1:4566/000000000000/secret_management_updates',
+          'http://127.0.0.1:4566/000000000000/secret_management_updates_lambda',
+        env: 'SQS_SECRET_UPDATES_LAMBDA'
+      },
+      queueOut: {
+        doc: 'A queue that normally sends messages to cdp portal backend',
+        format: String,
+        default: 'http://127.0.0.1:4566/000000000000/secret_management_updates',
         env: 'SQS_SECRET_UPDATES'
       },
       delay: {
-        doc: 'A delay before processing secrets  elf service and responded by a lambda',
+        doc: 'A delay before processing secrets and respond by a lambda',
         format: Number,
-        default: '2000',
+        default: '3',
         env: 'SQS_SECRET_UPDATES_DELAY'
       }
     }


### PR DESCRIPTION
Sets up a listener for an SQS queue that simulates the Lambda interacting with Secrets Manager.
Any messages coming in are then transformed and put on the queue that the portal backend listens to for secret updates.

It also forces an exception if a certain value is contained in the secret message.