### PR TITLE
CORE-3294: Clean up v1 shutter

### DIFF
--- a/src/api/lambda/monolambda/handlers/manage-shuttering-handler.js
+++ b/src/api/lambda/monolambda/handlers/manage-shuttering-handler.js
@@ -6,9 +6,6 @@ const schema = Joi.object({
   action: Joi.string().valid('shutter', 'unshutter').required(),
   fqdn: Joi.string().required(),
   service_name: Joi.string().required(),
-  // Optional: real mono-lambda resolves these from platform state
-  shutter_type: Joi.string().valid('www', 'api'),
-  web_acl_name: Joi.string(),
   dry_run: Joi.boolean().default(false)
 }).unknown(true)
 

--- a/src/api/lambda/monolambda/handlers/manage-shuttering-handler.js
+++ b/src/api/lambda/monolambda/handlers/manage-shuttering-handler.js
@@ -6,8 +6,9 @@ const schema = Joi.object({
   action: Joi.string().valid('shutter', 'unshutter').required(),
   fqdn: Joi.string().required(),
   service_name: Joi.string().required(),
-  shutter_type: Joi.string().valid('www', 'api').required(),
-  web_acl_name: Joi.string().required(),
+  // Optional: real mono-lambda resolves these from platform state
+  shutter_type: Joi.string().valid('www', 'api'),
+  web_acl_name: Joi.string(),
   dry_run: Joi.boolean().default(false)
 }).unknown(true)
 


### PR DESCRIPTION
The two fields are not send, so we don't need them required in the stubs:

https://github.com/DEFRA/cdp-portal-stubs/blob/f9a0d46e4a29a2d4726433bf03d6fce6a6759ad6/src/api/lambda/monolambda/handlers/manage-shuttering-handler.js#L5